### PR TITLE
Adding skip-mode functionality to initialize

### DIFF
--- a/initialize.py
+++ b/initialize.py
@@ -8,13 +8,6 @@
 <Authors>
   Albert Rafetseder
   Chintan Choksi
-
-<Started>
-  August, 2014
-
-<Authors>
-  Albert Rafetseder
-  Chintan Choksi
   
 <Purpose>
   This script does a ``git clone'' of all the dependent repositories

--- a/initialize.py
+++ b/initialize.py
@@ -42,9 +42,10 @@ import os
 import sys
 
 
+# config_initialize.txt contains links to repository and the directory where it
+# gets checked-out.
+# E.g.: https://github.com/SeattleTestbed/seash ../DEPENDENCIES/seash
 config_file = open("config_initialize.txt")
-# config_initialize.txt contains links to repository and the directory where it gets checked-out 
-# Eg: https://github.com/SeattleTestbed/seash ../DEPENDENCIES/seash
 
 if len(sys.argv) == 2 and sys.argv[1] == '-s':
   ignore_git_errors = True

--- a/initialize.py
+++ b/initialize.py
@@ -2,6 +2,13 @@
 <Program>
   initialize.py 
 
+<Started>
+  August, 2014
+
+<Authors>
+  Albert Rafetseder
+  Chintan Choksi
+  
 <Purpose>
   This script does a ``git clone'' of all the dependent repositories
   of a Seattle component.
@@ -11,11 +18,12 @@
       ``git clone https://github.com/SeattleTestbed/seash''
   * Change into the ``scripts'' subdirectory
   * Run this script: 
-      ``python initialize.py'' or "python initialize.py -s"
-        where -s activates skip-mode
-  * If Skip-mode is activated then 'initialize' would continue cloning of repos even on encountering git-errors    
-      
-  * The dependencies will be checked out into ``../DEPENDENCIES''.
+      ``python initialize.py''
+  * The dependencies will be checked out into ``../DEPENDENCIES''. 
+  *``initialize.py'' will get the list of dependencies to check-out from ``initialize.txt" file.
+  * During check-out, if there is a readme file associated with a repository, then it will be printed on terminal.
+  * Once this is done, run the build.py script to import the necessary files into a desired target folder.
+  * Run build file as:``python build.py''. 
 
 <Note>
   While this file is redistributed with every buildable Seattle repo, 
@@ -53,12 +61,12 @@ for line in config_file.readlines():
   if git_process.returncode == 0:
     print "Done!"
   else:
-      print "*** Error checking out repo. Git returned status code", git_process.returncode
-      print "*** Git messages on stdout: '" + stdout_data + "'."
-      print "*** Git messages on stderr: '" + stderr_data + "'."
-      print
-      if not ignore_git_errors:
-        print """Since the skip-mode is off, these errors need to be fixed before the build process can proceed. In 
+    print "*** Error checking out repo. Git returned status code", git_process.returncode
+    print "*** Git messages on stdout: '" + stdout_data + "'."
+    print "*** Git messages on stderr: '" + stderr_data + "'."
+    print
+    if not ignore_git_errors:
+      print """Since the skip-mode is off, these errors need to be fixed before the build process can proceed. In 
 doubt, please contact the Seattle development team at 
 
    seattle-devel@googlegroups.com
@@ -66,12 +74,12 @@ doubt, please contact the Seattle development team at
 and supply all of the above information. Thank you!
 
 """
-        print
-        sys.exit(1)
-      else:
-        print "Continuing with the cloning of directories as skip-mode is active"
-        print
-        continue
+      print
+      sys.exit(1)
+    else:
+      print "Continuing with the cloning of directories as skip-mode is active"
+      print
+      continue
 
 # If there is a readme file, show it to the user. 
 try:

--- a/initialize.py
+++ b/initialize.py
@@ -11,7 +11,10 @@
       ``git clone https://github.com/SeattleTestbed/seash''
   * Change into the ``scripts'' subdirectory
   * Run this script: 
-      ``python initialize.py''
+      ``python initialize.py'' or "python initialize.py -s"
+        where -s activates skip-mode
+  * If Skip-mode is activated then 'initialize' would continue cloning of repos even on encountering git-errors    
+      
   * The dependencies will be checked out into ``../DEPENDENCIES''.
 
 <Note>
@@ -26,6 +29,12 @@ import sys
 
 
 config_file = open("config_initialize.txt")
+
+
+if len(sys.argv) == 2 and sys.argv[1] == '-s':
+  ignore_git_errors = True
+else:
+  ignore_git_errors = False
 
 for line in config_file.readlines():
   # Ignore comments and blank lines
@@ -42,13 +51,14 @@ for line in config_file.readlines():
   # to see if it performed correctly, and halt the program (giving debug 
   # output) if not.
   if git_process.returncode == 0:
-     print "Done!"
+    print "Done!"
   else:
-    print "*** Error checking out repo. Git returned status code", git_process.returncode
-    print "*** Git messages on stdout: '" + stdout_data + "'."
-    print "*** Git messages on stderr: '" + stderr_data + "'."
-    print
-    print """These errors need to be fixed before the build process can proceed. In 
+      print "*** Error checking out repo. Git returned status code", git_process.returncode
+      print "*** Git messages on stdout: '" + stdout_data + "'."
+      print "*** Git messages on stderr: '" + stderr_data + "'."
+      print
+      if not ignore_git_errors:
+        print """Since the skip-mode is off, these errors need to be fixed before the build process can proceed. In 
 doubt, please contact the Seattle development team at 
 
    seattle-devel@googlegroups.com
@@ -56,8 +66,12 @@ doubt, please contact the Seattle development team at
 and supply all of the above information. Thank you!
 
 """
-    sys.exit(1)
-
+        print
+        sys.exit(1)
+      else:
+        print "Continuing with the cloning of directories as skip-mode is active"
+        print
+        continue
 
 # If there is a readme file, show it to the user. 
 try:

--- a/initialize.py
+++ b/initialize.py
@@ -37,7 +37,8 @@ import sys
 
 
 config_file = open("config_initialize.txt")
-
+# config_initialize.txt contains links to repository. 
+# Eg: https://github.com/SeattleTestbed/seash ../DEPENDENCIES/seash
 
 if len(sys.argv) == 2 and sys.argv[1] == '-s':
   ignore_git_errors = True

--- a/initialize.py
+++ b/initialize.py
@@ -3,7 +3,7 @@
   initialize.py 
   
 <Started>
-  August, 2014
+  August 2014.
 
 <Authors>
   Albert Rafetseder
@@ -16,14 +16,20 @@
 <Usage>
   * Clone the repository you would like to build on your machine, e.g. using 
       ``git clone https://github.com/SeattleTestbed/seash''
+  
   * Change into the ``scripts'' subdirectory
-  * Run this script: 
-      ``python initialize.py''
-  * The dependencies will be checked out into ``../DEPENDENCIES''. 
-  *``initialize.py'' will get the list of dependencies to check-out from ``config_initialize.txt" file.
-  * During check-out, if there is a readme file associated with a repository, then it will be printed on terminal.
-  * Once this is done, run the build.py script to import the necessary files into a desired target folder.
-  * Run build file as:``python build.py'' 
+  
+  * Run this script: ``python initialize.py''
+  
+  * The dependencies will be checked out into ``../DEPENDENCIES''
+  
+  *``initialize.py'' will get the list of dependencies to check-out from
+    ``config_initialize.txt" file.
+  
+  * During check-out, if there is a readme file associated with a repository,
+    then it will be printed on terminal.  Once this is done, run the build.py
+    script to import the necessary files into a desired target folder.  Run
+    build file as:``python build.py'' 
 
 <Note>
   While this file is redistributed with every buildable Seattle repo, 

--- a/initialize.py
+++ b/initialize.py
@@ -37,7 +37,7 @@ import sys
 
 
 config_file = open("config_initialize.txt")
-# config_initialize.txt contains links to repository. 
+# config_initialize.txt contains links to repository and the directory where it gets checked-out 
 # Eg: https://github.com/SeattleTestbed/seash ../DEPENDENCIES/seash
 
 if len(sys.argv) == 2 and sys.argv[1] == '-s':

--- a/initialize.py
+++ b/initialize.py
@@ -27,14 +27,10 @@
   * Run this script: 
       ``python initialize.py''
   * The dependencies will be checked out into ``../DEPENDENCIES''. 
-  *``initialize.py'' will get the list of dependencies to check-out from ``initialize.txt" file.
+  *``initialize.py'' will get the list of dependencies to check-out from ``config_initialize.txt" file.
   * During check-out, if there is a readme file associated with a repository, then it will be printed on terminal.
   * Once this is done, run the build.py script to import the necessary files into a desired target folder.
-<<<<<<< HEAD
   * Run build file as:``python build.py'' 
-=======
-  * Run build file as:``python build.py'' 
->>>>>>> origin/master
 
 <Note>
   While this file is redistributed with every buildable Seattle repo, 


### PR DESCRIPTION
The initialize.py script used to halt on any git-error. This pull request adds the skip-mode functionality wherein user can provide an option to the script to skip the git-errors and continue with the checking-out of the repos.
Resolves issue #1 
